### PR TITLE
App List: Use async on dispatch queue to prevent stuttering

### DIFF
--- a/StikJIT/Utilities/AppStoreIconFetcher.swift
+++ b/StikJIT/Utilities/AppStoreIconFetcher.swift
@@ -19,15 +19,19 @@ class AppStoreIconFetcher {
             return
         }
         
-        iconFetchDispatchQueue.sync {
+        iconFetchDispatchQueue.async {
             do {
                 let ans = try JITEnableContext.shared.getAppIcon(withBundleId: bundleID)
-                iconCache[bundleID] = ans
-                completion(ans)
+                DispatchQueue.main.async {
+                    iconCache[bundleID] = ans
+                    completion(ans)
+                }
             } catch {
                 print("Failed to get icon: \(error)")
-                completion(nil)
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
             }
         }
     }
-} 
+}


### PR DESCRIPTION
After tapping "Enabling JIT", scrolling the app list results in some stuttering when fetching the app icons.

Do the app icon fetching using the async instead of sync to fix this.