### PR TITLE
Warn user of no get-task-allow, fix ui hang after showAlert

### DIFF
--- a/StikJIT/StikJITApp.swift
+++ b/StikJIT/StikJITApp.swift
@@ -507,6 +507,7 @@ public func showAlert(title: String, message: String, showOk: Bool, showTryAgain
                 message: message,
                 onDismiss: {
                     // Called when tapped outside
+                    rootViewController?.presentedViewController?.dismiss(animated: true)
                     completion(false)
                 },
                 showButton: true,
@@ -529,12 +530,14 @@ public func showAlert(title: String, message: String, showOk: Bool, showTryAgain
                 message: message,
                 onDismiss: {
                     // Called when tapped outside
+                    rootViewController?.presentedViewController?.dismiss(animated: true)
                     completion(true)
                 },
                 showButton: true,
                 primaryButtonText: "OK",
                 onPrimaryButtonTap: {
                     // OK was tapped
+                    rootViewController?.presentedViewController?.dismiss(animated: true)
                     completion(true)
                 }
             )
@@ -550,6 +553,7 @@ public func showAlert(title: String, message: String, showOk: Bool, showTryAgain
                 title: title,
                 message: message,
                 onDismiss: {
+                    rootViewController?.presentedViewController?.dismiss(animated: true)
                     completion(false)
                 },
                 showButton: false

--- a/StikJIT/Utilities/Security.swift
+++ b/StikJIT/Utilities/Security.swift
@@ -1,0 +1,35 @@
+//
+//  Security.swift
+//  StikJIT
+//  from MeloNX
+//  Created by s s on 2025/4/6.
+//
+import Security
+
+
+typealias SecTaskRef = OpaquePointer
+@_silgen_name("SecTaskCopyValueForEntitlement")
+func SecTaskCopyValueForEntitlement(
+    _ task: SecTaskRef,
+    _ entitlement: NSString,
+    _ error: NSErrorPointer
+) -> CFTypeRef?
+
+@_silgen_name("SecTaskCreateFromSelf")
+func SecTaskCreateFromSelf(
+    _ allocator: CFAllocator?
+) -> SecTaskRef?
+
+func checkAppEntitlement(_ ent: String) -> Bool {
+    guard let task = SecTaskCreateFromSelf(nil) else {
+        print("Failed to create SecTask")
+        return false
+    }
+    
+    guard let entitlements = SecTaskCopyValueForEntitlement(task, ent as NSString, nil) else {
+        print("Failed to get entitlements")
+        return false
+    }
+    
+    return entitlements.boolValue != nil && entitlements.boolValue
+}

--- a/StikJIT/Views/Custom Error View.swift
+++ b/StikJIT/Views/Custom Error View.swift
@@ -68,7 +68,7 @@ struct CustomErrorView: View {
                     .padding(.horizontal, 12)
                 
                 // Message 
-                Text(message)
+                Text(LocalizedStringKey(message))
                     .font(.system(size: 15, design: .rounded))
                     .foregroundColor(colorScheme == .dark ? .white.opacity(0.9) : .black.opacity(0.9))
                     .multilineTextAlignment(.center)

--- a/StikJIT/Views/HomeView.swift
+++ b/StikJIT/Views/HomeView.swift
@@ -317,7 +317,12 @@ class InstalledAppsViewModel: ObservableObject {
             print(error)
             self.apps = [:]
         }
-
+        
+        if self.apps.count == 0 && !checkAppEntitlement("get-task-allow") && !UserDefaults.standard.bool(forKey: "skipGetTaskAllowCheck") {
+            showAlert(title: "Warning", message: "StikJIT is not signed with **get-task-allow**. It's OK, but if you also sign the app you want to enable JIT for with the same method, it\n\n ***WILL NOT WORK***.\n\nPlease sign the app you want to enable JIT for using a development certificate. You can disable this alert in settings.", showOk: true) { _ in
+                
+            }
+        }
     }
 }
 

--- a/StikJIT/Views/SettingsView.swift
+++ b/StikJIT/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @AppStorage("customBackgroundColor") private var customBackgroundColorHex: String = ""
     @AppStorage("selectedAppIcon") private var selectedAppIcon: String = "AppIcon"
     @AppStorage("autoQuitAfterEnablingJIT") private var doAutoQuitAfterEnablingJIT = false
+    @AppStorage("skipGetTaskAllowCheck") private var doSkipGetTaskAllowCheck = false
     @State private var isShowingPairingFilePicker = false
     @Environment(\.colorScheme) private var colorScheme
 
@@ -181,6 +182,9 @@ struct SettingsView: View {
                                 .padding(.bottom, 4)
                             
                             Toggle("Automatically Quit After Enabling JIT", isOn: $doAutoQuitAfterEnablingJIT)
+                                .foregroundColor(.primary)
+                                .padding(.vertical, 6)
+                            Toggle("Skip get-task-allow Check", isOn: $doSkipGetTaskAllowCheck)
                                 .foregroundColor(.primary)
                                 .padding(.vertical, 6)
                         }


### PR DESCRIPTION
1. Warn user of no get-task-allow if no app is found and StikJIT is not signed with get-task-allow. User can disable this warning in settings.
2. Fix CustomErrorView only becomes transparent but is not dismissed.