### PR TITLE
Change shortcut link to AutoJIT Homescreen Edition

### DIFF
--- a/StikJIT/Views/SettingsView.swift
+++ b/StikJIT/Views/SettingsView.swift
@@ -449,8 +449,8 @@ struct SettingsView: View {
                                 // New Discord Link
                                 LinkRow(icon: "bubble.left", title: "Join Discord", url: "https://discord.gg/ZnNcrRT3M8")
                                 
-                                //shortcut link
-                                LinkRow(icon: "sparkles", title: "iOS Shortcut", url: "https://www.icloud.com/shortcuts/f0c11c0a76654e63b18d8c59d82e152e")
+                                //autoJIT HomeScreen Edition shortcut link
+                                LinkRow(icon: "sparkles", title: "iOS Shortcut", url: "https://www.icloud.com/shortcuts/1e1b522ea1e045ebb0921d31870d8cb4")
                                 
                                 // StikNES promotion
                                 Button(action: {


### PR DESCRIPTION
The instructions for the shortcut are in the discord, but it should be pretty simple to figure it out. I can add the instructions to a text element inside of the shortcut before merging this change tonight if that's helpful. All you have to do is press select app, choose you app, and add the shortcut to homescreen.