### PR TITLE
Add build number for 18.4b1 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <div align="center">
   <h1><b>StikJIT</b></h1>
-  <p><i> An on-device JIT enabler for iOS versions 17.4+ (17.4-18.5b1 (latest), excluding iOS 18.4 beta 1), powered by <a href="https://github.com/jkcoxson/idevice">idevice</a> </i></p>
+  <p><i> An on-device JIT enabler for iOS versions 17.4+ (17.4-18.5b1 (latest)), excluding iOS 18.4 beta 1 (22E5200), powered by <a href="https://github.com/jkcoxson/idevice">idevice</a> </i></p>
 </div>
 <h6 align="center">
 


### PR DESCRIPTION
Just adding the build number for 18.4b1 because it´s easier then to find out if your 18.4 build is the first beta or a later 18.4 build