### PR TITLE
Add Source Identifier for Feather compatibility.

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1,5 +1,6 @@
 {
     "name": "StikJIT Repository",
+    "identifier": "com.stik.sj",
     "subtitle": "AltStore/SideStore compatible source repository for StikJIT.",
     "iconURL": "https://github.com/0-Blu/StikJIT/blob/main/assets/StikJIT.png?raw=true",
     "headerURL": "https://github.com/0-Blu/StikJIT/blob/main/assets/StikJIT.png?raw=true",


### PR DESCRIPTION
[Feather](https://github.com/khcrysalis/Feather) relies on the source having a root "identifier" key. #126 broke this. Re-adding ```"identifier": "com.stik.sj"``` to the root fixes this.